### PR TITLE
Merge provided `loaderOptions` into `defaultLoaderOptions`.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -55,9 +55,14 @@ const defaultLoaderOptions = {
   oneofs: true
 }
 
-export async function makeRequest (proto: string | string[], { beforeRequest, afterResponse, loaderOptions = defaultLoaderOptions, options = {}, ...clientConfig }: gRPCRequest): Promise<gRPCResponse> {
+export async function makeRequest (proto: string | string[], { beforeRequest, afterResponse, loaderOptions = {}, options = {}, ...clientConfig }: gRPCRequest): Promise<gRPCResponse> {
   return new Promise(async (resolve, reject) => {
     try {
+			loaderOptions = {
+				...loaderOptions ?? {},
+				...defaultLoaderOptions
+			};
+
       const packageDefinition = await protoLoader.load(proto, loaderOptions) as any
 
       const { requestSerialize, responseDeserialize, requestStream, responseStream } = packageDefinition[clientConfig.service][clientConfig.method]


### PR DESCRIPTION
Probably fixes stepci/stepci#223.

The `loaderOptions` is being merged into the default options provided by `defaultLoaderOptions`. This would be a breaking change for all consumers of `cool-grpc` which expect the optional `loaderOptions` to *replace* the defaults. `stepci/runner` should not be affected since it never provides the `loaderOptions` field. 